### PR TITLE
Updated image links to point to GitHub to avoid broken images in IBM …

### DIFF
--- a/multi_qubit_circuits.ipynb
+++ b/multi_qubit_circuits.ipynb
@@ -1,601 +1,599 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "multi-qubit-circuits.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (Ubuntu Linux)",
-      "language": "python",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/multi_qubit_circuits.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/multi_qubit_circuits.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "-Lh381LZkY9W"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Multi-qubit quantum circuits\n",
-        "Now we'll explore quantum circuits that contain more than one wire (qubit). The number of computational basis states doubles with each additional wire, so a three-wire circuit contains eight computational basis states, $\\vert000\\rangle$ through $\\vert111\\rangle$.\n",
-        "\n",
-        "To demonstrate multi-qubit circuits, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework. "
-      ]
-    },
-    {
-      "metadata": {
-        "id": "GjnUKZPdsnfZ",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#!pip install qiskit\n",
-        "# Include the necessary imports for this program\n",
-        "import numpy as np\n",
-        "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
-        "from qiskit import execute"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "gg2ag14rsnfd",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "In this first version of our circuit, we're going to use a simulator in Qiskit, referred to as \"statevector_simulator\", that will show us the quantum state upon running the circuit. This is not available on a real quantum computer, because we can't observe the quantum state directly; we can only infer it from measurements that collapse the quantum state into one basis state."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "6vFukG6vsnfe",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a Quantum Register with 3 qubits\n",
-        "qr = QuantumRegister(3)\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum register. Because we're going to use\n",
-        "# the statevector_simulator, we won't measure the circuit or need classical registers.\n",
-        "circ = QuantumCircuit(qr)\n",
-        "\n",
-        "# Place an X gate on the 2nd and 3rd wires. The topmost wire is index 0.\n",
-        "circ.x(qr[1])\n",
-        "circ.x(qr[2])\n",
-        "\n",
-        "# Draw the circuit\n",
-        "circ.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "LR9qRyQKsnfg",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now that the quantum circuit has been defined and drawn, let's execute it on a state vector simulator that will give us the quantum state of the circuit."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "m7kLzC8nsnfh",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer statevector_simulator backend\n",
-        "from qiskit import BasicAer\n",
-        "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
-        "\n",
-        "# Execute the circuit on the state vector simulator\n",
-        "job_sim = execute(circ, backend_sv_sim)\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "result_sim = job_sim.result()\n",
-        "\n",
-        "# Obtain the state vector for the quantum circuit\n",
-        "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
-        "\n",
-        "# Output the quantum state vector in a manner that contains a comma-delimited string.\n",
-        "quantum_state"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "FuUx8wVcsnfk",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### The quantum state vector\n",
-        "The output of the previously run cell contains a comma-separated string that represents the circuit's quantum state. Here are a few things to notice about this state vector:\n",
-        "\n",
-        "* There are $2^n$ dimensions in the vector (8 in this example), where $n$ is the number of wires in the circuit (3 in this example).\n",
-        "* Each dimension holds the amplitude of that dimension as a [complex number](https://en.wikipedia.org/wiki/Complex_number \"Complex number article on Wikipedia\").\n",
-        "* The sum of the squared absolute values of these amplitudes is 1\n",
-        "\n",
-        "In this example there is a 100% probability that a measurement will result in the state represented by dimension 6 (0 indexed) of this vector. This state is the $\\vert110\\rangle$ computational basis state, because $110$ is the binary representation of the number $6$. This matches the fact that the qubit states of the circuit are $\\vert1\\rangle$, $\\vert1\\rangle$ and $\\vert0\\rangle$ starting from the bottom of the circuit.\n",
-        "\n",
-        "The state vector of this simple circuit may be calculated by taking the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product \"Kronecker product article on Wikipedia\"), also known as tensor product, of its individual qubit states. Beginning from the most-significant qubit (which is on the bottom wire), perform the following calculation:\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}\\otimes\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}\\otimes\n",
-        " \\begin{bmatrix}\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  0 \\\\\n",
-        "  0 \\\\\n",
-        "  0 \\\\\n",
-        "  0 \\\\\n",
-        "  0 \\\\\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "Notice that the result of this calculation and the output of the get_statevector() method are equivalent. We'll now generate a visualization of the quantum state vector on a Q-sphere:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "JEZDEVOPsnfl",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the state vector on a Q-sphere\n",
-        "from qiskit.tools.visualization import plot_state_qsphere\n",
-        "plot_state_qsphere(quantum_state)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "WqtQfcMXsnfn",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Each line from the center of the sphere to the surface represents a computational basis state, with the opacity of the line reflecting its probability. Notice that there is only one line on this sphere, and you'll soon see that it represents computational basis state $\\vert110\\rangle$, consistent with the amplitudes in the state vector.\n",
-        "\n",
-        "#### Representing the $\\vert110\\rangle$ state on a Q-sphere\n",
-        "There are several ways to visualize multi-qubit quantum states, one such way being a Q-sphere. The following Q-sphere represents the $\\vert110\\rangle$ state.\n",
-        "<br/>\n",
-        "\n",
-        "<div align='center'><img src='images/qsphere-110-state.png' width=400 height=400 title='Q-sphere representation of the |110> state'>\n",
-        "</div>\n",
-        "\n",
-        "<br/>\n",
-        "Each of the computational basis states in a quantum state vector are arranged on the surface of a Q-sphere in the following way:\n",
-        "\n",
-        "* the all-zeros state, for example $\\vert000\\rangle$ in a three-qubit circuit, is at the top of the sphere\n",
-        "* the all-ones state, for example $\\vert111\\rangle$ in a three-qubit circuit, is at the bottom of the sphere\n",
-        "* each latitudinal line contains states that share the same [Hamming weight](https://en.wikipedia.org/wiki/Hamming_weight \"Hamming weight article on Wikipedia\") (number of ones in its bit string), with Hamming weights increasing moving downward on the sphere.\n",
-        "\n",
-        "Other features of this Q-sphere include:\n",
-        "\n",
-        "* The opacity of the radial line and volume of the ball associated with a state is proportional to its measurement probability.\n",
-        "* The color of a state's line and ball reflect its _phase_, which will be addressed in future lessons.\n",
-        "\n",
-        "The Q-sphere shown here is from the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\"), with which you may visualize multi-qubit quantum states as you interact with their individual Bloch spheres. Also, in the upper left corner of this application is a text field in which you may paste a comma-separated state vector such as the one generated earlier by the simulator. Doing so will cause the Q-sphere to represent the state vector.\n",
-        "\n",
-        "Now that we've examined the circuit's quantum state vector, we'll add measurements to the circuit and create an updated drawing."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "qTJMysLtJpsF",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a Classical Register with 3 bits\n",
-        "cr = ClassicalRegister(3)\n",
-        "\n",
-        "# Create the measurement portion of a quantum circuit\n",
-        "meas_circ = QuantumCircuit(qr, cr)\n",
-        "\n",
-        "# Create a barrier that separates the gates from the measurements\n",
-        "meas_circ.barrier(qr)\n",
-        "\n",
-        "# Measure the qubits into the classical registers\n",
-        "meas_circ.measure(qr, cr)\n",
-        "\n",
-        "# Add the measument circuit to the original circuit\n",
-        "complete_circuit = circ + meas_circ\n",
-        "\n",
-        "# Draw the new circuit\n",
-        "complete_circuit.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "EAsnHYI9snfr",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now we'll execute the updated circuit on a quantum simulator that includes measurements."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "q9VtcrnDKmd1",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer qasm_simulator backend\n",
-        "from qiskit import BasicAer\n",
-        "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 1000 times.\n",
-        "job_sim = execute(complete_circuit, backend_sim, shots=1000)\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "result_sim = job_sim.result()\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n",
-        "counts = result_sim.get_counts(complete_circuit)\n",
-        "print(counts)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "5__0oMx_snft",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The measurements for each shot should be $\\vert110\\rangle$ because the state vector indicated that the probability for that basis state is $1$. Recall that the square of the absolute value of a state's amplitude is the probability of a measurement resulting in that state. In this example:\n",
-        "$$\n",
-        " Pr(110) = \\left|1\\right|^2 = 1\n",
-        "$$\n",
-        "where $Pr$ means probability. We'll now plot a histogram of the results."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "-5ZQVEBF7Tqq",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the results on a histogram\n",
-        "from qiskit.tools.visualization import plot_histogram\n",
-        "plot_histogram(counts)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": true,
-        "id": "CkyK8kufsnfx",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "As you may have noticed, this example demonstrates only classical bit manipulation, so go ahead and create an example that leverages quantum mechanical properties. In the following cell, create a three-wire circuit with a Hadamard gate on each wire, and draw the circuit. You won't measure the circuit or need classical registers just yet:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "glI3rN4csnfy",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Include the necessary imports for this program\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Register with 3 qubits\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum register. Because we're going to use\n",
-        "# the statevector_simulator, we won't measure the circuit or need classical registers.\n",
-        "\n",
-        "\n",
-        "# Place Hadamard gate on each of the wires.\n",
-        "\n",
-        "\n",
-        "# Draw the circuit\n",
-        "\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "xe58SxpGsnf0",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now that the quantum circuit has been defined and drawn, execute it on a state vector simulator that calculates the quantum state of the circuit:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "njI_4XD7snf0",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer statevector_simulator backend\n",
-        "\n",
-        "\n",
-        "# Execute the circuit on the state vector simulator\n",
-        "\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "\n",
-        "\n",
-        "# Obtain the state vector for the quantum circuit\n",
-        "\n",
-        "\n",
-        "# Output the quantum state vector in a manner that contains a comma-delimited string.\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "nN3gTYfIsnf3",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Generate a visualization of the quantum state vector on a Q-sphere:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "IDzyPP4dsnf4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the state vector on a Q-sphere\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "P7G5HfAvsnf6",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Copy the comma-delimited string representing the state vector that was output in a previous step. Paste it into the text field in the upper left corner of the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\") to further visualize it in a Q-sphere.\n",
-        "\n",
-        "Add measurements to the circuit and create an updated drawing:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "wBP-8SDJsnf6",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a Classical Register with 3 bits\n",
-        "\n",
-        "\n",
-        "# Create the measurement portion of a quantum circuit\n",
-        "\n",
-        "\n",
-        "# Create a barrier that separates the gates from the measurements\n",
-        "\n",
-        "\n",
-        "# Measure the qubits into the classical registers\n",
-        "\n",
-        "\n",
-        "# Add the measument circuit to the original circuit\n",
-        "\n",
-        "\n",
-        "# Draw the new circuit\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "rvvdKc4Psnf8",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Execute the updated circuit on a quantum simulator that includes measurements:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "lLnpA1Husnf9",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer qasm_simulator backend\n",
-        "\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 1000 times.\n",
-        "\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "VXcAoAUUsnf_",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Plot a histogram of the results:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "brjPWQgWsngA",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the results on a histogram\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "EEcX-d44sngC",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The histogram should contain eight bars, with the measurements for each shot distributed fairly evenly among $\\vert000\\rangle$ through $\\vert111\\rangle$. The quantum state should be in an equal superposition.\n",
-        "\n",
-        "#### Examining this equal superposition state\n",
-        "If the circuit was constructed correctly, the resulting state vector dimensions will all have the same value, namely $\\approx0.354$, which is $\\frac{1}{\\sqrt{8}}$. Therefore, each computational basis state has an equal probability, exactly $\\frac{1}{8}$, of being the result of a measurement. Given that there are eight computational basis states, these probabilities add up to $1$ as they should.\n",
-        "\n",
-        "This quantum state matches the result of calculating the Kronecker product of the individual qubit states, which are themselves (after encountering a Hadamard) equal superpositions:\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\\otimes\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\\otimes\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}} \\\\\n",
-        "  \\frac{1}{\\sqrt{8}}\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "We could represent this state in Dirac notation in the following way:\n",
-        "$$\n",
-        " \\frac{1}{\\sqrt{8}}\\vert000\\rangle+\\frac{1}{\\sqrt{8}}\\vert001\\rangle+\\frac{1}{\\sqrt{8}}\\vert010\\rangle+\\frac{1}{\\sqrt{8}}\\vert011\\rangle+\\frac{1}{\\sqrt{8}}\\vert100\\rangle+\\frac{1}{\\sqrt{8}}\\vert101\\rangle+\\frac{1}{\\sqrt{8}}\\vert110\\rangle+\\frac{1}{\\sqrt{8}}\\vert111\\rangle\n",
-        "$$\n",
-        "\n",
-        "We could, more succinctly, leverage the [summation](https://en.wikipedia.org/wiki/Summation \"Summation on Wikipedia\") operator to represent the same state:\n",
-        "$$\n",
-        " \\frac{1}{\\sqrt{8}}\\sum_{x=0}^{7} \\vert{x}\\rangle\n",
-        "$$\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "Y6nHcS0csngD",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### It's your turn to play!\n",
-        "Here's a puzzle for you to solve. Starting with the most recent circuit, change one or more Hadamard gates to X gates in a manner that results in the following quantum state vector:\n",
-        "\n",
-        "$$\n",
-        " \\frac{1}{2}\\vert001\\rangle+\n",
-        " \\frac{1}{2}\\vert011\\rangle+\n",
-        " \\frac{1}{2}\\vert101\\rangle+\n",
-        " \\frac{1}{2}\\vert111\\rangle\n",
-        "$$\n",
-        "\n",
-        "To help solve this puzzle or to visualize the solution, experiment with the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\"). For this three-qubit circuit, you'd click individually on the three rightmost Bloch spheres, trying combinations of **X** and **H** gates. Clicking the $\\vert0\\rangle$ button will reset a qubit, and refreshing the browser will reset the app.\n",
-        "\n",
-        "<div align='center'><img src='images/quantum-spheres-screen-shot.png' width=600 title='Quantum spheres playground application'></div>\n",
-        "<br/>\n",
-        "\n",
-        "You've covered a lot of ground again in this lesson, particularly in the area of multi-qubit circuits. In this the next lesson we'll explore multi-qubit gates, including the mysterious concept of entanglement."
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-Lh381LZkY9W"
+   },
+   "source": [
+    "## Multi-qubit quantum circuits\n",
+    "Now we'll explore quantum circuits that contain more than one wire (qubit). The number of computational basis states doubles with each additional wire, so a three-wire circuit contains eight computational basis states, $\\vert000\\rangle$ through $\\vert111\\rangle$.\n",
+    "\n",
+    "To demonstrate multi-qubit circuits, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "GjnUKZPdsnfZ"
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install qiskit\n",
+    "# Include the necessary imports for this program\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
+    "from qiskit import execute"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "gg2ag14rsnfd"
+   },
+   "source": [
+    "In this first version of our circuit, we're going to use a simulator in Qiskit, referred to as \"statevector_simulator\", that will show us the quantum state upon running the circuit. This is not available on a real quantum computer, because we can't observe the quantum state directly; we can only infer it from measurements that collapse the quantum state into one basis state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "6vFukG6vsnfe"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Quantum Register with 3 qubits\n",
+    "qr = QuantumRegister(3)\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum register. Because we're going to use\n",
+    "# the statevector_simulator, we won't measure the circuit or need classical registers.\n",
+    "circ = QuantumCircuit(qr)\n",
+    "\n",
+    "# Place an X gate on the 2nd and 3rd wires. The topmost wire is index 0.\n",
+    "circ.x(qr[1])\n",
+    "circ.x(qr[2])\n",
+    "\n",
+    "# Draw the circuit\n",
+    "circ.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LR9qRyQKsnfg"
+   },
+   "source": [
+    "Now that the quantum circuit has been defined and drawn, let's execute it on a state vector simulator that will give us the quantum state of the circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "m7kLzC8nsnfh"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer statevector_simulator backend\n",
+    "from qiskit import BasicAer\n",
+    "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
+    "\n",
+    "# Execute the circuit on the state vector simulator\n",
+    "job_sim = execute(circ, backend_sv_sim)\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "result_sim = job_sim.result()\n",
+    "\n",
+    "# Obtain the state vector for the quantum circuit\n",
+    "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
+    "\n",
+    "# Output the quantum state vector in a manner that contains a comma-delimited string.\n",
+    "quantum_state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "FuUx8wVcsnfk"
+   },
+   "source": [
+    "#### The quantum state vector\n",
+    "The output of the previously run cell contains a comma-separated string that represents the circuit's quantum state. Here are a few things to notice about this state vector:\n",
+    "\n",
+    "* There are $2^n$ dimensions in the vector (8 in this example), where $n$ is the number of wires in the circuit (3 in this example).\n",
+    "* Each dimension holds the amplitude of that dimension as a [complex number](https://en.wikipedia.org/wiki/Complex_number \"Complex number article on Wikipedia\").\n",
+    "* The sum of the squared absolute values of these amplitudes is 1\n",
+    "\n",
+    "In this example there is a 100% probability that a measurement will result in the state represented by dimension 6 (0 indexed) of this vector. This state is the $\\vert110\\rangle$ computational basis state, because $110$ is the binary representation of the number $6$. This matches the fact that the qubit states of the circuit are $\\vert1\\rangle$, $\\vert1\\rangle$ and $\\vert0\\rangle$ starting from the bottom of the circuit.\n",
+    "\n",
+    "The state vector of this simple circuit may be calculated by taking the [Kronecker product](https://en.wikipedia.org/wiki/Kronecker_product \"Kronecker product article on Wikipedia\"), also known as tensor product, of its individual qubit states. Beginning from the most-significant qubit (which is on the bottom wire), perform the following calculation:\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}\\otimes\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}\\otimes\n",
+    " \\begin{bmatrix}\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  0 \\\\\n",
+    "  0 \\\\\n",
+    "  0 \\\\\n",
+    "  0 \\\\\n",
+    "  0 \\\\\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "Notice that the result of this calculation and the output of the get_statevector() method are equivalent. We'll now generate a visualization of the quantum state vector on a Q-sphere:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "JEZDEVOPsnfl"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the state vector on a Q-sphere\n",
+    "from qiskit.tools.visualization import plot_state_qsphere\n",
+    "plot_state_qsphere(quantum_state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "WqtQfcMXsnfn"
+   },
+   "source": [
+    "Each line from the center of the sphere to the surface represents a computational basis state, with the opacity of the line reflecting its probability. Notice that there is only one line on this sphere, and you'll soon see that it represents computational basis state $\\vert110\\rangle$, consistent with the amplitudes in the state vector.\n",
+    "\n",
+    "#### Representing the $\\vert110\\rangle$ state on a Q-sphere\n",
+    "There are several ways to visualize multi-qubit quantum states, one such way being a Q-sphere. The following Q-sphere represents the $\\vert110\\rangle$ state.\n",
+    "<br/>\n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/qsphere-110-state.png' width=400 height=400 title='Q-sphere representation of the |110> state'>\n",
+    "</div>\n",
+    "\n",
+    "<br/>\n",
+    "Each of the computational basis states in a quantum state vector are arranged on the surface of a Q-sphere in the following way:\n",
+    "\n",
+    "* the all-zeros state, for example $\\vert000\\rangle$ in a three-qubit circuit, is at the top of the sphere\n",
+    "* the all-ones state, for example $\\vert111\\rangle$ in a three-qubit circuit, is at the bottom of the sphere\n",
+    "* each latitudinal line contains states that share the same [Hamming weight](https://en.wikipedia.org/wiki/Hamming_weight \"Hamming weight article on Wikipedia\") (number of ones in its bit string), with Hamming weights increasing moving downward on the sphere.\n",
+    "\n",
+    "Other features of this Q-sphere include:\n",
+    "\n",
+    "* The opacity of the radial line and volume of the ball associated with a state is proportional to its measurement probability.\n",
+    "* The color of a state's line and ball reflect its _phase_, which will be addressed in future lessons.\n",
+    "\n",
+    "The Q-sphere shown here is from the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\"), with which you may visualize multi-qubit quantum states as you interact with their individual Bloch spheres. Also, in the upper left corner of this application is a text field in which you may paste a comma-separated state vector such as the one generated earlier by the simulator. Doing so will cause the Q-sphere to represent the state vector.\n",
+    "\n",
+    "Now that we've examined the circuit's quantum state vector, we'll add measurements to the circuit and create an updated drawing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qTJMysLtJpsF"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Classical Register with 3 bits\n",
+    "cr = ClassicalRegister(3)\n",
+    "\n",
+    "# Create the measurement portion of a quantum circuit\n",
+    "meas_circ = QuantumCircuit(qr, cr)\n",
+    "\n",
+    "# Create a barrier that separates the gates from the measurements\n",
+    "meas_circ.barrier(qr)\n",
+    "\n",
+    "# Measure the qubits into the classical registers\n",
+    "meas_circ.measure(qr, cr)\n",
+    "\n",
+    "# Add the measument circuit to the original circuit\n",
+    "complete_circuit = circ + meas_circ\n",
+    "\n",
+    "# Draw the new circuit\n",
+    "complete_circuit.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EAsnHYI9snfr"
+   },
+   "source": [
+    "Now we'll execute the updated circuit on a quantum simulator that includes measurements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "q9VtcrnDKmd1"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer qasm_simulator backend\n",
+    "from qiskit import BasicAer\n",
+    "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 1000 times.\n",
+    "job_sim = execute(complete_circuit, backend_sim, shots=1000)\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "result_sim = job_sim.result()\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n",
+    "counts = result_sim.get_counts(complete_circuit)\n",
+    "print(counts)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "5__0oMx_snft"
+   },
+   "source": [
+    "The measurements for each shot should be $\\vert110\\rangle$ because the state vector indicated that the probability for that basis state is $1$. Recall that the square of the absolute value of a state's amplitude is the probability of a measurement resulting in that state. In this example:\n",
+    "$$\n",
+    " Pr(110) = \\left|1\\right|^2 = 1\n",
+    "$$\n",
+    "where $Pr$ means probability. We'll now plot a histogram of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-5ZQVEBF7Tqq"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the results on a histogram\n",
+    "from qiskit.tools.visualization import plot_histogram\n",
+    "plot_histogram(counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "collapsed": true,
+    "id": "CkyK8kufsnfx"
+   },
+   "source": [
+    "As you may have noticed, this example demonstrates only classical bit manipulation, so go ahead and create an example that leverages quantum mechanical properties. In the following cell, create a three-wire circuit with a Hadamard gate on each wire, and draw the circuit. You won't measure the circuit or need classical registers just yet:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "glI3rN4csnfy"
+   },
+   "outputs": [],
+   "source": [
+    "# Include the necessary imports for this program\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Register with 3 qubits\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum register. Because we're going to use\n",
+    "# the statevector_simulator, we won't measure the circuit or need classical registers.\n",
+    "\n",
+    "\n",
+    "# Place Hadamard gate on each of the wires.\n",
+    "\n",
+    "\n",
+    "# Draw the circuit\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xe58SxpGsnf0"
+   },
+   "source": [
+    "Now that the quantum circuit has been defined and drawn, execute it on a state vector simulator that calculates the quantum state of the circuit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "njI_4XD7snf0"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer statevector_simulator backend\n",
+    "\n",
+    "\n",
+    "# Execute the circuit on the state vector simulator\n",
+    "\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "\n",
+    "\n",
+    "# Obtain the state vector for the quantum circuit\n",
+    "\n",
+    "\n",
+    "# Output the quantum state vector in a manner that contains a comma-delimited string.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "nN3gTYfIsnf3"
+   },
+   "source": [
+    "Generate a visualization of the quantum state vector on a Q-sphere:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "IDzyPP4dsnf4"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the state vector on a Q-sphere\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "P7G5HfAvsnf6"
+   },
+   "source": [
+    "Copy the comma-delimited string representing the state vector that was output in a previous step. Paste it into the text field in the upper left corner of the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\") to further visualize it in a Q-sphere.\n",
+    "\n",
+    "Add measurements to the circuit and create an updated drawing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "wBP-8SDJsnf6"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Classical Register with 3 bits\n",
+    "\n",
+    "\n",
+    "# Create the measurement portion of a quantum circuit\n",
+    "\n",
+    "\n",
+    "# Create a barrier that separates the gates from the measurements\n",
+    "\n",
+    "\n",
+    "# Measure the qubits into the classical registers\n",
+    "\n",
+    "\n",
+    "# Add the measument circuit to the original circuit\n",
+    "\n",
+    "\n",
+    "# Draw the new circuit\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rvvdKc4Psnf8"
+   },
+   "source": [
+    "Execute the updated circuit on a quantum simulator that includes measurements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "lLnpA1Husnf9"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer qasm_simulator backend\n",
+    "\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 1000 times.\n",
+    "\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "VXcAoAUUsnf_"
+   },
+   "source": [
+    "Plot a histogram of the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "brjPWQgWsngA"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the results on a histogram\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EEcX-d44sngC"
+   },
+   "source": [
+    "The histogram should contain eight bars, with the measurements for each shot distributed fairly evenly among $\\vert000\\rangle$ through $\\vert111\\rangle$. The quantum state should be in an equal superposition.\n",
+    "\n",
+    "#### Examining this equal superposition state\n",
+    "If the circuit was constructed correctly, the resulting state vector dimensions will all have the same value, namely $\\approx0.354$, which is $\\frac{1}{\\sqrt{8}}$. Therefore, each computational basis state has an equal probability, exactly $\\frac{1}{8}$, of being the result of a measurement. Given that there are eight computational basis states, these probabilities add up to $1$ as they should.\n",
+    "\n",
+    "This quantum state matches the result of calculating the Kronecker product of the individual qubit states, which are themselves (after encountering a Hadamard) equal superpositions:\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\\otimes\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\\otimes\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}} \\\\\n",
+    "  \\frac{1}{\\sqrt{8}}\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "We could represent this state in Dirac notation in the following way:\n",
+    "$$\n",
+    " \\frac{1}{\\sqrt{8}}\\vert000\\rangle+\\frac{1}{\\sqrt{8}}\\vert001\\rangle+\\frac{1}{\\sqrt{8}}\\vert010\\rangle+\\frac{1}{\\sqrt{8}}\\vert011\\rangle+\\frac{1}{\\sqrt{8}}\\vert100\\rangle+\\frac{1}{\\sqrt{8}}\\vert101\\rangle+\\frac{1}{\\sqrt{8}}\\vert110\\rangle+\\frac{1}{\\sqrt{8}}\\vert111\\rangle\n",
+    "$$\n",
+    "\n",
+    "We could, more succinctly, leverage the [summation](https://en.wikipedia.org/wiki/Summation \"Summation on Wikipedia\") operator to represent the same state:\n",
+    "$$\n",
+    " \\frac{1}{\\sqrt{8}}\\sum_{x=0}^{7} \\vert{x}\\rangle\n",
+    "$$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Y6nHcS0csngD"
+   },
+   "source": [
+    "#### It's your turn to play!\n",
+    "Here's a puzzle for you to solve. Starting with the most recent circuit, change one or more Hadamard gates to X gates in a manner that results in the following quantum state vector:\n",
+    "\n",
+    "$$\n",
+    " \\frac{1}{2}\\vert001\\rangle+\n",
+    " \\frac{1}{2}\\vert011\\rangle+\n",
+    " \\frac{1}{2}\\vert101\\rangle+\n",
+    " \\frac{1}{2}\\vert111\\rangle\n",
+    "$$\n",
+    "\n",
+    "To help solve this puzzle or to visualize the solution, experiment with the [Quantum Spheres Playground application](https://javafxpert.github.io/quantum-state-spheres/ \"Quantum Spheres Playground application\"). For this three-qubit circuit, you'd click individually on the three rightmost Bloch spheres, trying combinations of **X** and **H** gates. Clicking the $\\vert0\\rangle$ button will reset a qubit, and refreshing the browser will reset the app.\n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/quantum-spheres-screen-shot.png' width=600 title='Quantum spheres playground application'></div>\n",
+    "<br/>\n",
+    "\n",
+    "You've covered a lot of ground again in this lesson, particularly in the area of multi-qubit circuits. In this the next lesson we'll explore multi-qubit gates, including the mysterious concept of entanglement."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "multi-qubit-circuits.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/quantum_coin_flipping.ipynb
+++ b/quantum_coin_flipping.ipynb
@@ -1,407 +1,411 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "quantum_coin_flipping.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (Ubuntu Linux)",
-      "language": "python",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/quantum_coin_flipping.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/quantum_coin_flipping.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "-Lh381LZkY9W"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Flipping a coin quantumly\n",
-        "Coin flipping has often been used to make decisions and settle disputes. With a fair coin, each of the outcomes has a $\\frac{1}{2}$ probability. Coin flipping may be perfomed by a quantum computer with truly random results using just one quantum gate, because the [Hadamard](https://en.wikipedia.org/wiki/Quantum_logic_gate#Hadamard_(H)_gate \"Hadamard gate on Wikipedia\") gate can put a qubit into an equal superposition. When in this state, the qubit has a $\\frac{1}{2}$ probability of being measured $\\vert0\\rangle$, and a $\\frac{1}{2}$ probability of being measured $\\vert1\\rangle$.  \n",
-        "\n",
-        "To demonstrate the Hadamard gate, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework after we've imported the necessary items.\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "MFyUj-8yI9JG",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#!pip install qiskit\n",
-        "# Include the necessary imports for this program\n",
-        "import numpy as np\n",
-        "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
-        "from qiskit import execute"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "qTJMysLtJpsF",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a Quantum Register with 1 qubit (wire).\n",
-        "qr = QuantumRegister(1)\n",
-        "\n",
-        "# Create a Classical Register with 1 bit (double wire).\n",
-        "cr = ClassicalRegister(1)\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum and classical registers\n",
-        "circ = QuantumCircuit(qr, cr)\n",
-        "\n",
-        "# Place an Hadamard gate on the qubit wire\n",
-        "circ.h(qr[0])\n",
-        "\n",
-        "# Measure the qubit into the classical register\n",
-        "circ.measure(qr, cr)\n",
-        "\n",
-        "# Draw the circuit\n",
-        "circ.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "Ze1KvaGtumdf"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now that the quantum circuit has been defined and drawn, let's execute it on a quantum simulator, running the circuit 100 times. Each run and measurement of the circuit is called a *shot*."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "q9VtcrnDKmd1",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Import BasicAer\n",
-        "from qiskit import BasicAer\n",
-        "\n",
-        "# Use BasicAer's qasm_simulator\n",
-        "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 100 times.\n",
-        "job_sim = execute(circ, backend_sim, shots=100)\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "result_sim = job_sim.result()\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n",
-        "counts = result_sim.get_counts(circ)\n",
-        "print(counts)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "F1ZxWlWGyK-3"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The measurements for each run should be fairly evenly split between $\\vert0\\rangle$ and $\\vert1\\rangle$ as prescribed by the circuit. We'll now generate a visualization of the results."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "-5ZQVEBF7Tqq",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "from qiskit.tools.visualization import plot_histogram\n",
-        "\n",
-        "# Plot the results on a bar chart\n",
-        "plot_histogram(counts)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "-XgCp8Eb2nPA"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### Modeling the Hadamard gate with a matrix\n",
-        "The Hadamard gate may be represented by the following matrix using linear algebra.\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "To model the effect of the Hadamard gate on the $\\vert0\\rangle$ qubit, we'll multiply the matrix that represents the Hadamard gate by the vector that represents a $\\vert0\\rangle$ qubit.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}.\n",
-        " \\begin{bmatrix}\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "The result is a vector that represents a qubit in a quantum state commonly notated as as $\\vert+\\rangle$ and referred to as the _plus_ state.\n",
-        "\n",
-        "> Note: Our $\\vert+\\rangle$ state is just a symbol, and even though it's commonly used to represent the vector shown on the right, you may see it used elsewhere to represent other quantum states.\n",
-        "\n",
-        "Both of the dimensions of this vector hold the same amplitude, namely $\\frac{1}{\\sqrt{2}}$, approximately $0.7071$. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is $\\frac{1}{\\sqrt{2}}$ on the $\\vert0\\rangle$ axis, and $\\frac{1}{\\sqrt{2}}$ on the $\\vert1\\rangle$ axis. \n",
-        "\n",
-        "<div align='center'><img src='images/qubit-unit-plus.png' width=300 height=300 title='Plane representing |0> in vector space'></div>\n",
-        "<br/>\n",
-        "\n",
-        "#### Expressing our $\\vert+\\rangle$ state\n",
-        "So far we've seen a few ways to express our $\\vert+\\rangle$ state (as a vector, geometrically, and as a ket with a plus symbol). Another way to show it is with the following Dirac notation as two kets, each representing a dimension, and their amplitudes.\n",
-        "\n",
-        "$$\n",
-        "\\frac{1}{\\sqrt{2}}\\vert0\\rangle+\\frac{1}{\\sqrt{2}}\\vert1\\rangle\n",
-        "$$\n",
-        "\n",
-        "\n",
-        "> Note: A ket represents a column vector efficiently in part because dimensions with a 0 value are omitted, and coefficients with a value of 1 are implied. For example, the following two-dimensional vector is represented with just one ket because only one of the dimensions has a non-zero coefficient.\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}=\n",
-        " 0\\vert0\\rangle+1\\vert1\\rangle=\n",
-        " \\vert1\\rangle\n",
-        "$$\n",
-        "\n",
-        "No matter how we represent our $\\vert+\\rangle$ state, it has the same probability when measured of being a $\\vert0\\rangle$ qubit as it does of being a $\\vert1\\rangle$ qubit. This is because the squares of the absolute values of each dimension are equal, namely, $\\frac{1}{2}$.\n",
-        "\n",
-        "Now it's your turn to play! In the following cell, create a one-qubit circuit that uses an X gate followed by a Hadamard gate. Take a moment to think about what the results will be, then write some code after each of the comments and run each of the cells. First, create and draw the circuit:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "eCHFJ-hjsCJ4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Include the necessary imports for this program\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Register with 1 qubit (wire).\n",
-        "\n",
-        "\n",
-        "# Create a Classical Register with 1 bit (double wire).\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum and classical registers\n",
-        "\n",
-        "\n",
-        "# Place an X gate followed by a Hadamard gate on the qubit wire. The registers are zero-indexed.\n",
-        "\n",
-        "\n",
-        "# Measure the qubit into the classical register\n",
-        "\n",
-        "\n",
-        "# Draw the circuit\n",
-        "\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "10vTSykCsCJ6",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Next, run the circuit on a simulator, and print the measurement results:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Pu-omNpDsCJ7",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Import BasicAer\n",
-        "\n",
-        "\n",
-        "# Use BasicAer's qasm_simulator\n",
-        "\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 100 times.\n",
-        "\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "Pk3WL9P9sCJ9",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Finally, visualize the results on a histogram:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "sEe6PItDsCJ-",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the results on a bar chart"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "EkQotEAFsCKC",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The result of running the cell that you filled in should be a histogram containing two bars. As with the previous example with only a Hadamard gate, the measurements for each run should be fairly evenly split between $\\vert0\\rangle$ and $\\vert1\\rangle$. Let's take look at why this is the case.\n",
-        "\n",
-        "#### Effect of the Hadamard on $\\vert1\\rangle$\n",
-        "As noted previously, the Hadamard gate may be represented by the following matrix.\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "In the most recent circuit, the X gate transformed the initial $\\vert0\\rangle$ state into $\\vert1\\rangle$. Therefore, the Hadamard is operating on $\\vert1\\rangle$.\n",
-        "To model this, we'll multiply the matrix that represents the Hadamard gate by the vector that represents a $\\vert1\\rangle$ qubit.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}.\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  \\frac{1}{\\sqrt{2}} \\\\\n",
-        "  -\\frac{1}{\\sqrt{2}}\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "The result is a vector that represents a qubit in a quantum state commonly notated as $\\vert-\\rangle$ and referred to as the _minus_ state.\n",
-        "\n",
-        "> Note: As noted previously with the $\\vert+\\rangle$ state, our $\\vert-\\rangle$ state is just a symbol, and even though it's commonly used to represent the vector shown on the right, you may see it used elsewhere to represent other quantum states.\n",
-        "\n",
-        "Each of the dimensions of this vector holds a similar amplitude, differing only by their signs. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is $\\frac{1}{\\sqrt{2}}$ on the $\\vert0\\rangle$ axis, and $-\\frac{1}{\\sqrt{2}}$ on the $\\vert1\\rangle$ axis. \n",
-        "\n",
-        "<div align='center'><img src='images/qubit-unit-minus.png' width=300 height=300 title='Plane representing |0> in vector space'></div>\n",
-        "<br/>\n",
-        "\n",
-        "#### Expressing our $\\vert-\\rangle$ state\n",
-        "So far we've seen a few ways to express our $\\vert-\\rangle$ state (as a vector, geometrically, and as a ket with a minus symbol). Another way to show it is with the following Dirac notation as two kets, each representing a dimension, and their amplitudes.\n",
-        "\n",
-        "$$\n",
-        "\\frac{1}{\\sqrt{2}}\\vert0\\rangle-\\frac{1}{\\sqrt{2}}\\vert1\\rangle\n",
-        "$$\n",
-        "\n",
-        "\n",
-        "As with the $\\vert+\\rangle$ state previously, no matter how we represent our $\\vert-\\rangle$ state, it has the same probability when measured of being a $\\vert0\\rangle$ qubit as it does of being a $\\vert1\\rangle$ qubit. This is because the squares of the absolute values of each dimension are equal, namely, $\\frac{1}{2}$.\n",
-        "\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "BqGAovPfsCKC",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### Representing $\\vert+\\rangle$ and $\\vert-\\rangle$ states on a Bloch sphere\n",
-        "Qubit states are often represented on a [_Bloch sphere_](https://en.wikipedia.org/wiki/Bloch_sphere), with the $\\vert0\\rangle$ computational basis state at the top of the sphere, and the $\\vert1\\rangle$ computational basis state at the bottom of the sphere. In addition, each of the infinite number of points on the surface of the Bloch sphere are valid qubit states. Our $\\vert+\\rangle$ and $\\vert-\\rangle$ are two such states, as shown in the following spheres. The first sphere represents a $\\vert+\\rangle$ qubit, and second sphere represents a $\\vert-\\rangle$ qubit.\n",
-        "\n",
-        "<div align='center'><img src='images/bloch-plus-state.png' width=375 height=337 title='Bloch sphere representation of the |+> state'>\n",
-        "<img src='images/bloch-minus-state.png' width=375 height=337 title='Bloch sphere representation of the |-> state'></div>\n",
-        "<br/>\n",
-        "\n",
-        "The spheres shown here are from the [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"), which displays information about the state on a Bloch sphere in additional ways. For example:\n",
-        "* the vertical bar on the left of each Bloch sphere indicates the probability of measuring the $\\vert0\\rangle$ state, $0.5$ in each of these cases. Note that the top of the dark portion of the bar is at the same vertical position as the arrow on the Bloch sphere (relative to the X/Y plane). This quality of a Bloch sphere makes it intuitive to visually estimate measurement probabilities.\n",
-        "\n",
-        "* the phase disk below each of the Bloch spheres indicates the _relative phase_ of a qubit, expressed in radians ($\\pi$ radians = $180$ degrees). The phases contained in quantum states cause the constructive and destructive interference that enables many quantum algorithms.\n",
-        "\n",
-        "#### Behavior of the Hadamard gate on a Bloch sphere\n",
-        "The behavior of the Hadamard gate on a Bloch sphere is that the line & arrow rotates $\\pi$ radians ($180$ degrees) around the diagonal X+Z axis. For example, a Hadamard gate applied to a $\\vert0\\rangle$ qubit results in the $\\vert+\\rangle$ shown on the first Bloch sphere, and a Hadamard gate applied to a $\\vert1\\rangle$ qubit results in the $\\vert-\\rangle$ shown on the second Bloch sphere. As with the X gate, applying a Hadamard gate twice results in the initial state. \n",
-        "\n",
-        "#### Your turn to play!\n",
-        "To get a better feel for the behavior of the Hadamard gate, go ahead and experiment with this [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"). Use the buttons labeled *$\\vert0\\rangle$*, *$\\vert1\\rangle$*, and *H* and notice how the line & arrow are positioned after each click. There are several other gates on the right side of the application with which you can experiment, even if you aren't yet familiar with them. Playing around will give you some intuition about their behavior in advance of when you study them more formally.\n",
-        "\n",
-        "<div align='center'><img src='images/grok-bloch-screen-shot.png' width=600 title='Bloch sphere playground application'></div>\n",
-        "<br/>\n",
-        "\n",
-        "You've covered a lot of ground in this lesson! Some of the topics mentioned briefly here, such as leveraging interference in quantum computing applications, will be explored in some depth in future lessons."
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-Lh381LZkY9W"
+   },
+   "source": [
+    "# Flipping a coin quantumly\n",
+    "Coin flipping has often been used to make decisions and settle disputes. With a fair coin, each of the outcomes has a $\\frac{1}{2}$ probability. Coin flipping may be perfomed by a quantum computer with truly random results using just one quantum gate, because the [Hadamard](https://en.wikipedia.org/wiki/Quantum_logic_gate#Hadamard_(H)_gate \"Hadamard gate on Wikipedia\") gate can put a qubit into an equal superposition. When in this state, the qubit has a $\\frac{1}{2}$ probability of being measured $\\vert0\\rangle$, and a $\\frac{1}{2}$ probability of being measured $\\vert1\\rangle$.  \n",
+    "\n",
+    "To demonstrate the Hadamard gate, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework after we've imported the necessary items.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "MFyUj-8yI9JG"
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install qiskit\n",
+    "# Include the necessary imports for this program\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
+    "from qiskit import execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qTJMysLtJpsF"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Quantum Register with 1 qubit (wire).\n",
+    "qr = QuantumRegister(1)\n",
+    "\n",
+    "# Create a Classical Register with 1 bit (double wire).\n",
+    "cr = ClassicalRegister(1)\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum and classical registers\n",
+    "circ = QuantumCircuit(qr, cr)\n",
+    "\n",
+    "# Place an Hadamard gate on the qubit wire\n",
+    "circ.h(qr[0])\n",
+    "\n",
+    "# Measure the qubit into the classical register\n",
+    "circ.measure(qr, cr)\n",
+    "\n",
+    "# Draw the circuit\n",
+    "circ.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ze1KvaGtumdf"
+   },
+   "source": [
+    "Now that the quantum circuit has been defined and drawn, let's execute it on a quantum simulator, running the circuit 100 times. Each run and measurement of the circuit is called a *shot*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "q9VtcrnDKmd1"
+   },
+   "outputs": [],
+   "source": [
+    "# Import BasicAer\n",
+    "from qiskit import BasicAer\n",
+    "\n",
+    "# Use BasicAer's qasm_simulator\n",
+    "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 100 times.\n",
+    "job_sim = execute(circ, backend_sim, shots=100)\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "result_sim = job_sim.result()\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n",
+    "counts = result_sim.get_counts(circ)\n",
+    "print(counts)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "F1ZxWlWGyK-3"
+   },
+   "source": [
+    "The measurements for each run should be fairly evenly split between $\\vert0\\rangle$ and $\\vert1\\rangle$ as prescribed by the circuit. We'll now generate a visualization of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-5ZQVEBF7Tqq"
+   },
+   "outputs": [],
+   "source": [
+    "from qiskit.tools.visualization import plot_histogram\n",
+    "\n",
+    "# Plot the results on a bar chart\n",
+    "plot_histogram(counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-XgCp8Eb2nPA"
+   },
+   "source": [
+    "#### Modeling the Hadamard gate with a matrix\n",
+    "The Hadamard gate may be represented by the following matrix using linear algebra.\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "To model the effect of the Hadamard gate on the $\\vert0\\rangle$ qubit, we'll multiply the matrix that represents the Hadamard gate by the vector that represents a $\\vert0\\rangle$ qubit.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}.\n",
+    " \\begin{bmatrix}\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "The result is a vector that represents a qubit in a quantum state commonly notated as as $\\vert+\\rangle$ and referred to as the _plus_ state.\n",
+    "\n",
+    "> Note: Our $\\vert+\\rangle$ state is just a symbol, and even though it's commonly used to represent the vector shown on the right, you may see it used elsewhere to represent other quantum states.\n",
+    "\n",
+    "Both of the dimensions of this vector hold the same amplitude, namely $\\frac{1}{\\sqrt{2}}$, approximately $0.7071$. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is $\\frac{1}{\\sqrt{2}}$ on the $\\vert0\\rangle$ axis, and $\\frac{1}{\\sqrt{2}}$ on the $\\vert1\\rangle$ axis. \n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/qubit-unit-plus.png' width=300 height=300 title='Plane representing |0> in vector space'></div>\n",
+    "<br/>\n",
+    "\n",
+    "#### Expressing our $\\vert+\\rangle$ state\n",
+    "So far we've seen a few ways to express our $\\vert+\\rangle$ state (as a vector, geometrically, and as a ket with a plus symbol). Another way to show it is with the following Dirac notation as two kets, each representing a dimension, and their amplitudes.\n",
+    "\n",
+    "$$\n",
+    "\\frac{1}{\\sqrt{2}}\\vert0\\rangle+\\frac{1}{\\sqrt{2}}\\vert1\\rangle\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "> Note: A ket represents a column vector efficiently in part because dimensions with a 0 value are omitted, and coefficients with a value of 1 are implied. For example, the following two-dimensional vector is represented with just one ket because only one of the dimensions has a non-zero coefficient.\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}=\n",
+    " 0\\vert0\\rangle+1\\vert1\\rangle=\n",
+    " \\vert1\\rangle\n",
+    "$$\n",
+    "\n",
+    "No matter how we represent our $\\vert+\\rangle$ state, it has the same probability when measured of being a $\\vert0\\rangle$ qubit as it does of being a $\\vert1\\rangle$ qubit. This is because the squares of the absolute values of each dimension are equal, namely, $\\frac{1}{2}$.\n",
+    "\n",
+    "Now it's your turn to play! In the following cell, create a one-qubit circuit that uses an X gate followed by a Hadamard gate. Take a moment to think about what the results will be, then write some code after each of the comments and run each of the cells. First, create and draw the circuit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "eCHFJ-hjsCJ4"
+   },
+   "outputs": [],
+   "source": [
+    "# Include the necessary imports for this program\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Register with 1 qubit (wire).\n",
+    "\n",
+    "\n",
+    "# Create a Classical Register with 1 bit (double wire).\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum and classical registers\n",
+    "\n",
+    "\n",
+    "# Place an X gate followed by a Hadamard gate on the qubit wire. The registers are zero-indexed.\n",
+    "\n",
+    "\n",
+    "# Measure the qubit into the classical register\n",
+    "\n",
+    "\n",
+    "# Draw the circuit\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "10vTSykCsCJ6"
+   },
+   "source": [
+    "Next, run the circuit on a simulator, and print the measurement results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Pu-omNpDsCJ7"
+   },
+   "outputs": [],
+   "source": [
+    "# Import BasicAer\n",
+    "\n",
+    "\n",
+    "# Use BasicAer's qasm_simulator\n",
+    "\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 100 times.\n",
+    "\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Pk3WL9P9sCJ9"
+   },
+   "source": [
+    "Finally, visualize the results on a histogram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sEe6PItDsCJ-"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the results on a bar chart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EkQotEAFsCKC"
+   },
+   "source": [
+    "The result of running the cell that you filled in should be a histogram containing two bars. As with the previous example with only a Hadamard gate, the measurements for each run should be fairly evenly split between $\\vert0\\rangle$ and $\\vert1\\rangle$. Let's take look at why this is the case.\n",
+    "\n",
+    "#### Effect of the Hadamard on $\\vert1\\rangle$\n",
+    "As noted previously, the Hadamard gate may be represented by the following matrix.\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "In the most recent circuit, the X gate transformed the initial $\\vert0\\rangle$ state into $\\vert1\\rangle$. Therefore, the Hadamard is operating on $\\vert1\\rangle$.\n",
+    "To model this, we'll multiply the matrix that represents the Hadamard gate by the vector that represents a $\\vert1\\rangle$ qubit.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} & \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  \\frac{1}{\\sqrt{2}} & -\\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}.\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  \\frac{1}{\\sqrt{2}} \\\\\n",
+    "  -\\frac{1}{\\sqrt{2}}\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "The result is a vector that represents a qubit in a quantum state commonly notated as $\\vert-\\rangle$ and referred to as the _minus_ state.\n",
+    "\n",
+    "> Note: As noted previously with the $\\vert+\\rangle$ state, our $\\vert-\\rangle$ state is just a symbol, and even though it's commonly used to represent the vector shown on the right, you may see it used elsewhere to represent other quantum states.\n",
+    "\n",
+    "Each of the dimensions of this vector holds a similar amplitude, differing only by their signs. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is $\\frac{1}{\\sqrt{2}}$ on the $\\vert0\\rangle$ axis, and $-\\frac{1}{\\sqrt{2}}$ on the $\\vert1\\rangle$ axis. \n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/qubit-unit-minus.png' width=300 height=300 title='Plane representing |0> in vector space'></div>\n",
+    "<br/>\n",
+    "\n",
+    "#### Expressing our $\\vert-\\rangle$ state\n",
+    "So far we've seen a few ways to express our $\\vert-\\rangle$ state (as a vector, geometrically, and as a ket with a minus symbol). Another way to show it is with the following Dirac notation as two kets, each representing a dimension, and their amplitudes.\n",
+    "\n",
+    "$$\n",
+    "\\frac{1}{\\sqrt{2}}\\vert0\\rangle-\\frac{1}{\\sqrt{2}}\\vert1\\rangle\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "As with the $\\vert+\\rangle$ state previously, no matter how we represent our $\\vert-\\rangle$ state, it has the same probability when measured of being a $\\vert0\\rangle$ qubit as it does of being a $\\vert1\\rangle$ qubit. This is because the squares of the absolute values of each dimension are equal, namely, $\\frac{1}{2}$.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "BqGAovPfsCKC"
+   },
+   "source": [
+    "#### Representing $\\vert+\\rangle$ and $\\vert-\\rangle$ states on a Bloch sphere\n",
+    "Qubit states are often represented on a [_Bloch sphere_](https://en.wikipedia.org/wiki/Bloch_sphere), with the $\\vert0\\rangle$ computational basis state at the top of the sphere, and the $\\vert1\\rangle$ computational basis state at the bottom of the sphere. In addition, each of the infinite number of points on the surface of the Bloch sphere are valid qubit states. Our $\\vert+\\rangle$ and $\\vert-\\rangle$ are two such states, as shown in the following spheres. The first sphere represents a $\\vert+\\rangle$ qubit, and second sphere represents a $\\vert-\\rangle$ qubit.\n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/bloch-plus-state.png' width=375 height=337 title='Bloch sphere representation of the |+> state'>\n",
+    "<img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/bloch-minus-state.png' width=375 height=337 title='Bloch sphere representation of the |-> state'></div>\n",
+    "<br/>\n",
+    "\n",
+    "The spheres shown here are from the [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"), which displays information about the state on a Bloch sphere in additional ways. For example:\n",
+    "* the vertical bar on the left of each Bloch sphere indicates the probability of measuring the $\\vert0\\rangle$ state, $0.5$ in each of these cases. Note that the top of the dark portion of the bar is at the same vertical position as the arrow on the Bloch sphere (relative to the X/Y plane). This quality of a Bloch sphere makes it intuitive to visually estimate measurement probabilities.\n",
+    "\n",
+    "* the phase disk below each of the Bloch spheres indicates the _relative phase_ of a qubit, expressed in radians ($\\pi$ radians = $180$ degrees). The phases contained in quantum states cause the constructive and destructive interference that enables many quantum algorithms.\n",
+    "\n",
+    "#### Behavior of the Hadamard gate on a Bloch sphere\n",
+    "The behavior of the Hadamard gate on a Bloch sphere is that the line & arrow rotates $\\pi$ radians ($180$ degrees) around the diagonal X+Z axis. For example, a Hadamard gate applied to a $\\vert0\\rangle$ qubit results in the $\\vert+\\rangle$ shown on the first Bloch sphere, and a Hadamard gate applied to a $\\vert1\\rangle$ qubit results in the $\\vert-\\rangle$ shown on the second Bloch sphere. As with the X gate, applying a Hadamard gate twice results in the initial state. \n",
+    "\n",
+    "#### Your turn to play!\n",
+    "To get a better feel for the behavior of the Hadamard gate, go ahead and experiment with this [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"). Use the buttons labeled *$\\vert0\\rangle$*, *$\\vert1\\rangle$*, and *H* and notice how the line & arrow are positioned after each click. There are several other gates on the right side of the application with which you can experiment, even if you aren't yet familiar with them. Playing around will give you some intuition about their behavior in advance of when you study them more formally.\n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/grok-bloch-screen-shot.png' width=600 title='Bloch sphere playground application'></div>\n",
+    "<br/>\n",
+    "\n",
+    "You've covered a lot of ground in this lesson! Some of the topics mentioned briefly here, such as leveraging interference in quantum computing applications, will be explored in some depth in future lessons."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "quantum_coin_flipping.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/quantum_not_gate_qiskit.ipynb
+++ b/quantum_not_gate_qiskit.ipynb
@@ -1,373 +1,377 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "quantum_not_gate_qiskit.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (Ubuntu Linux)",
-      "language": "python",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/quantum_not_gate_qiskit.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/quantum_not_gate_qiskit.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "-Lh381LZkY9W"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# The quantum version of a NOT gate\n",
-        "In classical programming, a [NOT gate](https://bit.ly/2SmqonO) turns a 0 bit into a 1 bit, and vice-versa. The quantum version of a NOT gate is the X gate, often referred to as the [Pauli-X gate](https://en.wikipedia.org/wiki/Quantum_logic_gate#Pauli-X_gate). It turns a [qubit](https://en.wikipedia.org/wiki/Qubit) symbolized in a [Dirac notation](https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation \"Dirac notation article on Wikipedia\") _ket_ by $\\vert0\\rangle$ into a $\\vert1\\rangle$, and vice-versa. These $\\vert0\\rangle$ and $\\vert1\\rangle$ qubits are quantum states, specifically _computational basis states_, and they are the quantum counterparts of the classical 0 and 1 bits. The X gate also operates on quantum states that are in some combination, or *superposition*, of the $\\vert0\\rangle$and $\\vert1\\rangle$ computational basis states. To demonstrate the X gate, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework after we've imported the necessary items.\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "MFyUj-8yI9JG",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#!pip install qiskit\n",
-        "# Include the necessary imports for this program\n",
-        "import numpy as np\n",
-        "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
-        "from qiskit import execute"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "qTJMysLtJpsF",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a Quantum Register with 1 qubit (wire).\n",
-        "qr = QuantumRegister(1)\n",
-        "\n",
-        "# Create a Classical Register with 1 bit (double wire).\n",
-        "cr = ClassicalRegister(1)\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum and classical registers\n",
-        "circ = QuantumCircuit(qr, cr)\n",
-        "\n",
-        "# Place an X gate on the qubit wire. The registers are zero-indexed.\n",
-        "circ.x(qr[0])\n",
-        "\n",
-        "# Measure the qubit into the classical register\n",
-        "circ.measure(qr, cr)\n",
-        "\n",
-        "# Draw the circuit\n",
-        "circ.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "Ze1KvaGtumdf"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now that the quantum circuit has been defined and drawn, let's execute it on a quantum simulator, running the circuit 100 times. Each run and measurement of the circuit is called a *shot*."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "q9VtcrnDKmd1",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Import BasicAer\n",
-        "from qiskit import BasicAer\n",
-        "\n",
-        "# Use BasicAer's qasm_simulator\n",
-        "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 100 times.\n",
-        "job_sim = execute(circ, backend_sim, shots=100)\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "result_sim = job_sim.result()\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n",
-        "counts = result_sim.get_counts(circ)\n",
-        "print(counts)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "F1ZxWlWGyK-3"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The measurement for each run should be $\\vert1\\rangle$ as prescribed by the circuit. We'll now generate a visualization of the results."
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "-5ZQVEBF7Tqq",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "from qiskit.tools.visualization import plot_histogram\n",
-        "\n",
-        "# Plot the results on a bar chart\n",
-        "plot_histogram(counts)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "-XgCp8Eb2nPA"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Now it's your turn to play! In the following cell, create a one-qubit circuit that uses two X gates so that the measurements result in the initial state of the qubit. To try your hand at this, write some code after each of the comments and run each of the cells. First, create and draw the circuit:"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "code",
-        "id": "gLJdvWsB36rz",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Include the necessary imports for this program\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Register with 1 qubit (wire).\n",
-        "\n",
-        "\n",
-        "# Create a Classical Register with 1 bit (double wire).\n",
-        "\n",
-        "\n",
-        "# Create a Quantum Circuit from the quantum and classical registers\n",
-        "\n",
-        "\n",
-        "# Place two X gates on the qubit wire. The registers are zero-indexed.\n",
-        "\n",
-        "\n",
-        "# Measure the qubit into the classical register\n",
-        "\n",
-        "\n",
-        "# Draw the circuit\n",
-        "\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "MmDyhRydrAMa",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Next, run the circuit on a simulator, and print the measurement results:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "yRiJFmSUrAMb",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Import BasicAer\n",
-        "\n",
-        "\n",
-        "# Use BasicAer's qasm_simulator\n",
-        "\n",
-        "\n",
-        "# Execute the circuit on the qasm simulator, running it 100 times.\n",
-        "\n",
-        "\n",
-        "# Grab the results from the job.\n",
-        "\n",
-        "\n",
-        "# Print the counts, which are contained in a Python dictionary\n",
-        "\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "LinG0rLcrAMe",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Finally, visualize the results on a histogram:"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "RFmnsDtLrAMe",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the results on a bar chart\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": false,
-        "id": "3U03pKa067WK"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "The result of running the cell that you filled in should be a histogram containing one bar. This bar should indicate that the measurements of each of the 100 shots resulted in the $\\vert0\\rangle$ quantum state.\n",
-        "\n",
-        "Now that you've successfully created a quantum circuit that contains an X gate, let's take a look at how it may be modeled using linear algebra.\n",
-        "\n",
-        "#### Modeling a qubit with a vector\n",
-        "In linear algebra terms, the $\\vert0\\rangle$ qubit is represented by the following two-dimensional vector.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        " \n",
-        "The first element, or dimension, of this vector holds the _amplitude_ of the $\\vert0\\rangle$ computational basis state. The second dimension of this vector holds the amplitude of the $\\vert1\\rangle$ computational basis state. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is 1 on the $\\vert0\\rangle$ axis, and 0 on the $\\vert1\\rangle$ axis. \n",
-        "\n",
-        "<div align='center'><img src='images/qubit-unit-zero.png' width=240 height=240 title='Plane representing |0> in vector space'></div>\n",
-        "<br/>\n",
-        "Similarly, the following vector represents the $\\vert1\\rangle$ qubit.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "In the corresponding unit circle, the vector is drawn from the origin to the point that is 0 on the $\\vert0\\rangle$ axis, and 1 on the $\\vert1\\rangle$ axis. \n",
-        "\n",
-        "<div align='center'><img src='images/qubit-unit-one.png' width=240 height=240 title='Plane representing |1> in vector space'></div>\n",
-        "\n",
-        "The probability that a qubit, when measured, will result in a given computational basis state is the square of the absolute value of that computational basis state's amplitude. Therefore, the measurement of a qubit represented by the first vector shown previously results in the $\\vert0\\rangle$ computational basis state, and the measurement of a qubit represented by the second vector shown previously results in the $\\vert1\\rangle$ computational basis state.\n",
-        "\n",
-        "#### Modeling a quantum gate with a matrix\n",
-        "Quantum gates may be represented with matrices in linear algebra. For example, the X gate is represented by the following matrix.\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 & 1 \\\\\n",
-        "  1 & 0\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "To model the effect of a quantum gate on a qubit, we'll multiply the matrix that represents the X gate by the vector that represents a $\\vert0\\rangle$ qubit.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 & 1 \\\\\n",
-        "  1 & 0\n",
-        " \\end{bmatrix}.\n",
-        " \\begin{bmatrix}\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n",
-        "The result is a vector that represents the $\\vert1\\rangle$ qubit.\n",
-        "\n",
-        "Some quantum gates, when applied twice, result in the original quantum state. The X gate has that quality, as shown in the following multiplication of the X gate matrix by a vector that represents a $\\vert1\\rangle$ qubit. The result is a vector that represents a $\\vert0\\rangle$ qubit.\n",
-        "\n",
-        "$$\n",
-        " \\begin{bmatrix}\n",
-        "  0 & 1 \\\\\n",
-        "  1 & 0\n",
-        " \\end{bmatrix}.\n",
-        " \\begin{bmatrix}\n",
-        "  0 \\\\\n",
-        "  1\n",
-        " \\end{bmatrix}=\n",
-        " \\begin{bmatrix}\n",
-        "  1 \\\\\n",
-        "  0\n",
-        " \\end{bmatrix}\n",
-        "$$\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "9R5YSPOerAMi",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### Representing a qubit on a Bloch sphere\n",
-        "Qubit states are often represented on a [_Bloch sphere_](https://en.wikipedia.org/wiki/Bloch_sphere), with the $\\vert0\\rangle$ computational basis state at the top of the sphere, and the $\\vert1\\rangle$ computational basis state at the bottom of the sphere. The sphere on the left represents a $\\vert0\\rangle$ qubit, as the line & arrow points to the top of the sphere. Similarly, the sphere on the right represents a $\\vert1\\rangle$ qubit, with the line & arrow pointing to the bottom of the sphere.\n",
-        "\n",
-        "<div align='center'><img src='images/bloch-0-state.png' width=250 height=250 title='Bloch sphere representation of the |0> state'>\n",
-        "<img src='images/bloch-1-state.png' width=250 height=250 title='Bloch sphere representation of the |1> state'></div>\n",
-        "\n",
-        "#### Behavior of quantum gates on the Bloch sphere\n",
-        "Each quantum gate, including the X gate, transforms a quantum state to a (usually) different one. The behavior of these transformations on a Bloch sphere is that the line & arrow rotates to another point on the surface. Specifically, the X gate rotates $\\pi$ radians ($180$ degrees) around the X axis. For example, the Bloch sphere on the left results in the Bloch sphere on the right, and vice-versa.\n",
-        "\n",
-        "#### Your turn to play with Bloch spheres\n",
-        "To get a better feel for how Bloch spheres represent qubits and the behavior of quantum gates, go ahead and experiment with this [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"). Use the buttons labeled *$\\vert0\\rangle$*, *$\\vert1\\rangle$*, and *X* and notice how the line & arrow are positioned after each click. There are several other gates on the right side of the application with which you can experiment, even if you aren't yet familiar with them. Playing around will give you some intuition about their behavior in advance of when you study them more formally. \n",
-        "\n",
-        "[<div align='center'><img src='images/grok-bloch-screen-shot.png' width=600 title='Bloch sphere playground application'></div>](https://javafxpert.github.io/grok-bloch/)\n",
-        "<br/>\n",
-        "\n",
-        "Note that each of the infinite number of points on the surface of the Bloch sphere are valid qubit states. As mentioned earlier, these states are combinations, or superpositions, of the $\\vert0\\rangle$ and $\\vert1\\rangle$ computational basis states. Leveraging these superpositional states is one thing that separates quantum computing from classical computing, and will be explored further in upcoming lessons."
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-Lh381LZkY9W"
+   },
+   "source": [
+    "# The quantum version of a NOT gate\n",
+    "In classical programming, a [NOT gate](https://bit.ly/2SmqonO) turns a 0 bit into a 1 bit, and vice-versa. The quantum version of a NOT gate is the X gate, often referred to as the [Pauli-X gate](https://en.wikipedia.org/wiki/Quantum_logic_gate#Pauli-X_gate). It turns a [qubit](https://en.wikipedia.org/wiki/Qubit) symbolized in a [Dirac notation](https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation \"Dirac notation article on Wikipedia\") _ket_ by $\\vert0\\rangle$ into a $\\vert1\\rangle$, and vice-versa. These $\\vert0\\rangle$ and $\\vert1\\rangle$ qubits are quantum states, specifically _computational basis states_, and they are the quantum counterparts of the classical 0 and 1 bits. The X gate also operates on quantum states that are in some combination, or *superposition*, of the $\\vert0\\rangle$and $\\vert1\\rangle$ computational basis states. To demonstrate the X gate, we'll create a simple quantum circuit with the [Qiskit](https://qiskit.org/) framework after we've imported the necessary items.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "MFyUj-8yI9JG"
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install qiskit\n",
+    "# Include the necessary imports for this program\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister\n",
+    "from qiskit import execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qTJMysLtJpsF"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a Quantum Register with 1 qubit (wire).\n",
+    "qr = QuantumRegister(1)\n",
+    "\n",
+    "# Create a Classical Register with 1 bit (double wire).\n",
+    "cr = ClassicalRegister(1)\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum and classical registers\n",
+    "circ = QuantumCircuit(qr, cr)\n",
+    "\n",
+    "# Place an X gate on the qubit wire. The registers are zero-indexed.\n",
+    "circ.x(qr[0])\n",
+    "\n",
+    "# Measure the qubit into the classical register\n",
+    "circ.measure(qr, cr)\n",
+    "\n",
+    "# Draw the circuit\n",
+    "circ.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ze1KvaGtumdf"
+   },
+   "source": [
+    "Now that the quantum circuit has been defined and drawn, let's execute it on a quantum simulator, running the circuit 100 times. Each run and measurement of the circuit is called a *shot*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "q9VtcrnDKmd1"
+   },
+   "outputs": [],
+   "source": [
+    "# Import BasicAer\n",
+    "from qiskit import BasicAer\n",
+    "\n",
+    "# Use BasicAer's qasm_simulator\n",
+    "backend_sim = BasicAer.get_backend('qasm_simulator')\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 100 times.\n",
+    "job_sim = execute(circ, backend_sim, shots=100)\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "result_sim = job_sim.result()\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n",
+    "counts = result_sim.get_counts(circ)\n",
+    "print(counts)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "F1ZxWlWGyK-3"
+   },
+   "source": [
+    "The measurement for each run should be $\\vert1\\rangle$ as prescribed by the circuit. We'll now generate a visualization of the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-5ZQVEBF7Tqq"
+   },
+   "outputs": [],
+   "source": [
+    "from qiskit.tools.visualization import plot_histogram\n",
+    "\n",
+    "# Plot the results on a bar chart\n",
+    "plot_histogram(counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-XgCp8Eb2nPA"
+   },
+   "source": [
+    "Now it's your turn to play! In the following cell, create a one-qubit circuit that uses two X gates so that the measurements result in the initial state of the qubit. To try your hand at this, write some code after each of the comments and run each of the cells. First, create and draw the circuit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "gLJdvWsB36rz"
+   },
+   "outputs": [],
+   "source": [
+    "# Include the necessary imports for this program\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Register with 1 qubit (wire).\n",
+    "\n",
+    "\n",
+    "# Create a Classical Register with 1 bit (double wire).\n",
+    "\n",
+    "\n",
+    "# Create a Quantum Circuit from the quantum and classical registers\n",
+    "\n",
+    "\n",
+    "# Place two X gates on the qubit wire. The registers are zero-indexed.\n",
+    "\n",
+    "\n",
+    "# Measure the qubit into the classical register\n",
+    "\n",
+    "\n",
+    "# Draw the circuit\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "MmDyhRydrAMa"
+   },
+   "source": [
+    "Next, run the circuit on a simulator, and print the measurement results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "yRiJFmSUrAMb"
+   },
+   "outputs": [],
+   "source": [
+    "# Import BasicAer\n",
+    "\n",
+    "\n",
+    "# Use BasicAer's qasm_simulator\n",
+    "\n",
+    "\n",
+    "# Execute the circuit on the qasm simulator, running it 100 times.\n",
+    "\n",
+    "\n",
+    "# Grab the results from the job.\n",
+    "\n",
+    "\n",
+    "# Print the counts, which are contained in a Python dictionary\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "LinG0rLcrAMe"
+   },
+   "source": [
+    "Finally, visualize the results on a histogram:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "RFmnsDtLrAMe"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the results on a bar chart\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "3U03pKa067WK"
+   },
+   "source": [
+    "The result of running the cell that you filled in should be a histogram containing one bar. This bar should indicate that the measurements of each of the 100 shots resulted in the $\\vert0\\rangle$ quantum state.\n",
+    "\n",
+    "Now that you've successfully created a quantum circuit that contains an X gate, let's take a look at how it may be modeled using linear algebra.\n",
+    "\n",
+    "#### Modeling a qubit with a vector\n",
+    "In linear algebra terms, the $\\vert0\\rangle$ qubit is represented by the following two-dimensional vector.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    " \n",
+    "The first element, or dimension, of this vector holds the _amplitude_ of the $\\vert0\\rangle$ computational basis state. The second dimension of this vector holds the amplitude of the $\\vert1\\rangle$ computational basis state. This is shown geometrically in the following unit circle that represents the qubit's two-dimensional vector space. The vector is drawn from the origin to the point that is 1 on the $\\vert0\\rangle$ axis, and 0 on the $\\vert1\\rangle$ axis. \n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/qubit-unit-zero.png' width=240 height=240 title='Plane representing |0> in vector space'></div>\n",
+    "<br/>\n",
+    "Similarly, the following vector represents the $\\vert1\\rangle$ qubit.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "In the corresponding unit circle, the vector is drawn from the origin to the point that is 0 on the $\\vert0\\rangle$ axis, and 1 on the $\\vert1\\rangle$ axis. \n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/qubit-unit-one.png' width=240 height=240 title='Plane representing |1> in vector space'></div>\n",
+    "\n",
+    "The probability that a qubit, when measured, will result in a given computational basis state is the square of the absolute value of that computational basis state's amplitude. Therefore, the measurement of a qubit represented by the first vector shown previously results in the $\\vert0\\rangle$ computational basis state, and the measurement of a qubit represented by the second vector shown previously results in the $\\vert1\\rangle$ computational basis state.\n",
+    "\n",
+    "#### Modeling a quantum gate with a matrix\n",
+    "Quantum gates may be represented with matrices in linear algebra. For example, the X gate is represented by the following matrix.\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 & 1 \\\\\n",
+    "  1 & 0\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "To model the effect of a quantum gate on a qubit, we'll multiply the matrix that represents the X gate by the vector that represents a $\\vert0\\rangle$ qubit.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 & 1 \\\\\n",
+    "  1 & 0\n",
+    " \\end{bmatrix}.\n",
+    " \\begin{bmatrix}\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n",
+    "The result is a vector that represents the $\\vert1\\rangle$ qubit.\n",
+    "\n",
+    "Some quantum gates, when applied twice, result in the original quantum state. The X gate has that quality, as shown in the following multiplication of the X gate matrix by a vector that represents a $\\vert1\\rangle$ qubit. The result is a vector that represents a $\\vert0\\rangle$ qubit.\n",
+    "\n",
+    "$$\n",
+    " \\begin{bmatrix}\n",
+    "  0 & 1 \\\\\n",
+    "  1 & 0\n",
+    " \\end{bmatrix}.\n",
+    " \\begin{bmatrix}\n",
+    "  0 \\\\\n",
+    "  1\n",
+    " \\end{bmatrix}=\n",
+    " \\begin{bmatrix}\n",
+    "  1 \\\\\n",
+    "  0\n",
+    " \\end{bmatrix}\n",
+    "$$\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "9R5YSPOerAMi"
+   },
+   "source": [
+    "#### Representing a qubit on a Bloch sphere\n",
+    "Qubit states are often represented on a [_Bloch sphere_](https://en.wikipedia.org/wiki/Bloch_sphere), with the $\\vert0\\rangle$ computational basis state at the top of the sphere, and the $\\vert1\\rangle$ computational basis state at the bottom of the sphere. The sphere on the left represents a $\\vert0\\rangle$ qubit, as the line & arrow points to the top of the sphere. Similarly, the sphere on the right represents a $\\vert1\\rangle$ qubit, with the line & arrow pointing to the bottom of the sphere.\n",
+    "\n",
+    "<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/bloch-0-state.png' width=250 height=250 title='Bloch sphere representation of the |0> state'>\n",
+    "<img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/bloch-1-state.png' width=250 height=250 title='Bloch sphere representation of the |1> state'></div>\n",
+    "\n",
+    "#### Behavior of quantum gates on the Bloch sphere\n",
+    "Each quantum gate, including the X gate, transforms a quantum state to a (usually) different one. The behavior of these transformations on a Bloch sphere is that the line & arrow rotates to another point on the surface. Specifically, the X gate rotates $\\pi$ radians ($180$ degrees) around the X axis. For example, the Bloch sphere on the left results in the Bloch sphere on the right, and vice-versa.\n",
+    "\n",
+    "#### Your turn to play with Bloch spheres\n",
+    "To get a better feel for how Bloch spheres represent qubits and the behavior of quantum gates, go ahead and experiment with this [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch \"grok-bloch application\"). Use the buttons labeled *$\\vert0\\rangle$*, *$\\vert1\\rangle$*, and *X* and notice how the line & arrow are positioned after each click. There are several other gates on the right side of the application with which you can experiment, even if you aren't yet familiar with them. Playing around will give you some intuition about their behavior in advance of when you study them more formally. \n",
+    "\n",
+    "[<div align='center'><img src='https://raw.githubusercontent.com/JavaFXpert/qiskit4devs-workshop-notebooks/master/images/grok-bloch-screen-shot.png' width=600 title='Bloch sphere playground application'></div>](https://javafxpert.github.io/grok-bloch/)\n",
+    "<br/>\n",
+    "\n",
+    "Note that each of the infinite number of points on the surface of the Bloch sphere are valid qubit states. As mentioned earlier, these states are combinations, or superpositions, of the $\\vert0\\rangle$ and $\\vert1\\rangle$ computational basis states. Leveraging these superpositional states is one thing that separates quantum computing from classical computing, and will be explored further in upcoming lessons."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "quantum_not_gate_qiskit.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/rotating_around_bloch.ipynb
+++ b/rotating_around_bloch.ipynb
@@ -1,230 +1,238 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "quantum_not_gate_qiskit.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (Ubuntu Linux)",
-      "language": "python",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/rotating_around_bloch.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/JavaFXpert/qiskit4devs-workshop-notebooks/blob/master/rotating_around_bloch.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
-    {
-      "metadata": {
-        "colab_type": "text",
-        "collapsed": true,
-        "id": "-Lh381LZkY9W"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Rotating around the Bloch sphere\n",
-        "Single-qubit gates may be visualized as rotations around the Bloch sphere. For example, recall that applying an *X* gate results in a $\\pi$ rotation around the X axis. Take a few minutes to read the [Single-Qubit Gates](https://qiskit.org/documentation/terra/summary_of_quantum_operations.html#single-qubit-gates) section of the Qiskit Terra documentation, focusing on the *X*, *Y*, *Z*, *S*, *S$\\dagger$*, *T*, *T$\\dagger$*, *Rx*, *Ry* and *Rz* gates. As you're reading about the behavior of each gate and the [unitary matrices](https://en.wikipedia.org/wiki/Unitary_matrix) that model them, use the [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch/) to visualize their rotations and effect on the qubit's state. Some gates, including *Z*, *Rz*, *S*, *S$\\dagger$*, *T* and *T$\\dagger$* rotate exclusively around the Z axis, therefore affecting the qubit's phase but not its amplitudes or measurement probabilities. Other gates, including *X*, *Rx*, *Y* and *Ry* affect its amplitudes, and consequently its measurement probabilities.\n",
-        "\n",
-        "Suppose we wanted a qubit to evolve from state $\\vert0\\rangle$ to a state whose probability of measuring $\\vert1\\rangle$ is approximately 0.85 and whose phase is $\\pi$. One approach would be to use the _Bloch sphere playground application_ to try rotations that achieve that state. Doing so shows that applying an *Ry* gate with a rotation angle $\\theta$ of $-3\\pi/4$ will do the trick. The following code leverages this gate and angle to produce the desired state."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "eI2ad3aJWcKg",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "#!pip install qiskit\n",
-        "# Do the usual setup, but without classical registers or measurement\n",
-        "import numpy as np\n",
-        "from qiskit import QuantumCircuit, QuantumRegister, execute\n",
-        "\n",
-        "qr = QuantumRegister(1)\n",
-        "circ = QuantumCircuit(qr)\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "9S3q9oI0XK4i",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "\n",
-        "# Place an Ry gate with a −3π/4 rotation\n",
-        "circ.ry(-3/4 * np.pi, qr[0])\n",
-        "\n",
-        "# Draw the circuit\n",
-        "circ.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "Nf9fLNluWcKk",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "We'll use the statevector simulator to verify that we've achieved the desired state"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "cztKMdLeWcKl",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer statevector_simulator backend\n",
-        "from qiskit import BasicAer\n",
-        "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
-        "\n",
-        "job_sim = execute(circ, backend_sv_sim)\n",
-        "result_sim = job_sim.result()\n",
-        "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
-        "\n",
-        "# Output the quantum state vector\n",
-        "quantum_state"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "Zma8WE38WcKn",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Notice that the desired probabilities have been achieved, as squaring the absolute values of the $\\vert1\\rangle$ amplitude $-0.924$ results in approximately 0.85. Let's visualize this state on the Bloch sphere."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "aSsGGqJTWcKn",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the state vector on a Bloch sphere\n",
-        "from qiskit.tools.visualization import plot_bloch_multivector\n",
-        "plot_bloch_multivector(quantum_state)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "R-2If2lPWcKp",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### Now it's your turn to play!\n",
-        "Here's a challenge for you: In the following cells, modify the circuit to achieve a qubit state whose probability of measuring $\\vert0\\rangle$ is 0.75, and phase is $\\pi/4$ \n"
-      ]
-    },
-    {
-      "metadata": {
-        "scrolled": true,
-        "id": "lZkGk9WrWcKq",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Do the usual setup, but without classical registers or measurement\n",
-        "import numpy as np\n",
-        "from qiskit import QuantumCircuit, QuantumRegister, execute\n",
-        "\n",
-        "qr = QuantumRegister(1)\n",
-        "circ = QuantumCircuit(qr)\n",
-        "\n",
-        "# Place gates that will achieve the desired state\n",
-        "\n",
-        "\n",
-        "# Draw the circuit\n",
-        "circ.draw(output='mpl')\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "istNd1WWWcKs",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Use the BasicAer statevector_simulator backend\n",
-        "from qiskit import BasicAer\n",
-        "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
-        "\n",
-        "job_sim = execute(circ, backend_sv_sim)\n",
-        "result_sim = job_sim.result()\n",
-        "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
-        "\n",
-        "# Output the quantum state vector\n",
-        "quantum_state"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "fulhcY4uWcKu",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Plot the state vector on a Bloch sphere\n",
-        "from qiskit.tools.visualization import plot_bloch_multivector\n",
-        "plot_bloch_multivector(quantum_state)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "collapsed": false,
-        "id": "6pFGKnJ1WcKw",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "#### One more challenge before you go\n",
-        "\n",
-        "Recall that the Hadamard gate rotates the state on the Bloch sphere $\\pi$ radians around the diagonal X+Z axis. Because of this behavior, inserting a phase rotation gate between two Hadamard gates has the effect of converting the Z rotation into an X rotation. This is used by some quantum computing algorithms to trade phase with probability amplitudes while in a superposition. Your challenge is to create a circuit (in the cells above) that contains two Hadamard gates with a phase rotation gate in-between them. The probability of measuring $\\vert0\\rangle$ must be approximately 0.85.\n",
-        "\n",
-        "Enjoy this challenge, and congratulations on the progress you've made on your quantum computing journey!"
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "collapsed": true,
+    "id": "-Lh381LZkY9W"
+   },
+   "source": [
+    "## Rotating around the Bloch sphere\n",
+    "Single-qubit gates may be visualized as rotations around the Bloch sphere. For example, recall that applying an *X* gate results in a $\\pi$ rotation around the X axis. Take a few minutes to read the [Single-Qubit Gates](https://quantum-computing.ibm.com/jupyter/tutorial/fundamentals/7_summary_of_quantum_operations.ipynb) section of the Qiskit Terra documentation, focusing on the *X*, *Y*, *Z*, *S*, *S$\\dagger$*, *T*, *T$\\dagger$*, *Rx*, *Ry* and *Rz* gates. As you're reading about the behavior of each gate and the [unitary matrices](https://en.wikipedia.org/wiki/Unitary_matrix) that model them, use the [Bloch sphere playground application](https://javafxpert.github.io/grok-bloch/) to visualize their rotations and effect on the qubit's state. Some gates, including *Z*, *Rz*, *S*, *S$\\dagger$*, *T* and *T$\\dagger$* rotate exclusively around the Z axis, therefore affecting the qubit's phase but not its amplitudes or measurement probabilities. Other gates, including *X*, *Rx*, *Y* and *Ry* affect its amplitudes, and consequently its measurement probabilities.\n",
+    "\n",
+    "Suppose we wanted a qubit to evolve from state $\\vert0\\rangle$ to a state whose probability of measuring $\\vert1\\rangle$ is approximately 0.85 and whose phase is $\\pi$. One approach would be to use the _Bloch sphere playground application_ to try rotations that achieve that state. Doing so shows that applying an *Ry* gate with a rotation angle $\\theta$ of $-3\\pi/4$ will do the trick. The following code leverages this gate and angle to produce the desired state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "eI2ad3aJWcKg"
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install qiskit\n",
+    "# Do the usual setup, but without classical registers or measurement\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, QuantumRegister, execute\n",
+    "\n",
+    "qr = QuantumRegister(1)\n",
+    "circ = QuantumCircuit(qr)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9S3q9oI0XK4i"
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Place an Ry gate with a −3π/4 rotation\n",
+    "circ.ry(-3/4 * np.pi, qr[0])\n",
+    "\n",
+    "# Draw the circuit\n",
+    "circ.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Nf9fLNluWcKk"
+   },
+   "source": [
+    "We'll use the statevector simulator to verify that we've achieved the desired state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "cztKMdLeWcKl"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer statevector_simulator backend\n",
+    "from qiskit import BasicAer\n",
+    "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
+    "\n",
+    "job_sim = execute(circ, backend_sv_sim)\n",
+    "result_sim = job_sim.result()\n",
+    "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
+    "\n",
+    "# Output the quantum state vector\n",
+    "quantum_state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Zma8WE38WcKn"
+   },
+   "source": [
+    "Notice that the desired probabilities have been achieved, as squaring the absolute values of the $\\vert1\\rangle$ amplitude $-0.924$ results in approximately 0.85. Let's visualize this state on the Bloch sphere."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "aSsGGqJTWcKn"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the state vector on a Bloch sphere\n",
+    "from qiskit.tools.visualization import plot_bloch_multivector\n",
+    "plot_bloch_multivector(quantum_state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "R-2If2lPWcKp"
+   },
+   "source": [
+    "#### Now it's your turn to play!\n",
+    "Here's a challenge for you: In the following cells, modify the circuit to achieve a qubit state whose probability of measuring $\\vert0\\rangle$ is 0.75, and phase is $\\pi/4$ \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "lZkGk9WrWcKq",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Do the usual setup, but without classical registers or measurement\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, QuantumRegister, execute\n",
+    "\n",
+    "qr = QuantumRegister(1)\n",
+    "circ = QuantumCircuit(qr)\n",
+    "\n",
+    "# Place gates that will achieve the desired state\n",
+    "\n",
+    "\n",
+    "# Draw the circuit\n",
+    "circ.draw(output='mpl')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "istNd1WWWcKs"
+   },
+   "outputs": [],
+   "source": [
+    "# Use the BasicAer statevector_simulator backend\n",
+    "from qiskit import BasicAer\n",
+    "backend_sv_sim = BasicAer.get_backend('statevector_simulator')\n",
+    "\n",
+    "job_sim = execute(circ, backend_sv_sim)\n",
+    "result_sim = job_sim.result()\n",
+    "quantum_state = result_sim.get_statevector(circ, decimals=3)\n",
+    "\n",
+    "# Output the quantum state vector\n",
+    "quantum_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "fulhcY4uWcKu"
+   },
+   "outputs": [],
+   "source": [
+    "# Plot the state vector on a Bloch sphere\n",
+    "from qiskit.tools.visualization import plot_bloch_multivector\n",
+    "plot_bloch_multivector(quantum_state)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "6pFGKnJ1WcKw"
+   },
+   "source": [
+    "#### One more challenge before you go\n",
+    "\n",
+    "Recall that the Hadamard gate rotates the state on the Bloch sphere $\\pi$ radians around the diagonal X+Z axis. Because of this behavior, inserting a phase rotation gate between two Hadamard gates has the effect of converting the Z rotation into an X rotation. This is used by some quantum computing algorithms to trade phase with probability amplitudes while in a superposition. Your challenge is to create a circuit (in the cells above) that contains two Hadamard gates with a phase rotation gate in-between them. The probability of measuring $\\vert0\\rangle$ must be approximately 0.85.\n",
+    "\n",
+    "Enjoy this challenge, and congratulations on the progress you've made on your quantum computing journey!"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "quantum_not_gate_qiskit.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
…Qx environment.

Here's the promised pull request. I have updated the links in the notebooks to point to the image files on GitHub. With this fix, the images will now display correctly when the notebooks are opened in IBM Qx, and in a local environment with network connection. The images will not display in a local, non-connected environment unless they have opened the notebooks while connected, and thus created checkpoints with images loaded.